### PR TITLE
chore: rebrand explorer to Libra2XP

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 build
 coverage
 public/world.json
+public/_redirects
 robots.txt
 .husky/
 .prettierignore

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aptos Explorer
+# Libra2XP
 
 ## How to use
 

--- a/index.html
+++ b/index.html
@@ -7,21 +7,21 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network."
+      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Libra2 Network."
     />
-    <meta property="og:title" content="Aptos Explorer" />
+    <meta property="og:title" content="Libra2 Explorer" />
     <meta
       property="og:description"
-      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Aptos Network."
+      content="Explore transactions, accounts, events, nodes, gas fees and other network activity within the Libra2 Network."
     />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <title>Aptos Explorer</title>
+    <title>Libra2 Explorer</title>
     <!--
-      This url refers to a css file in adobe fonts/typekit that includes the fonts configured in the aptos web project. The project id is "ifl8enc" which is used in the url.
+      This url refers to a css file in adobe fonts/typekit that includes the fonts configured in the Libra2 web project. The project id is "ifl8enc" which is used in the url.
 
       Fonts used at the time of writing are: (this is configurable in the adobe typekit project and subject to change).
 
@@ -54,7 +54,7 @@
       })(document, "script", "head");
     </script>
 
-    <!-- Hotjar Tracking Code for https://explorer.aptoslabs.com/ -->
+    <!-- Hotjar Tracking Code for https://explorer.libra2.org/ -->
     <script>
       (function (h, o, t, j, a, r) {
         h.hj =

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aptos-explorer",
+  "name": "libra2xp",
   "version": "0.0.1",
   "private": true,
   "packageManager": "pnpm@10.10.0",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/proposals/*  https://governance.aptosfoundation.org
-/*    /index.html   200 
+/proposals/*  https://governance.libra2.org
+/*    /index.html   200

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Aptos Explorer",
-  "name": "Aptos Block Explorer",
+  "short_name": "Libra2 Explorer",
+  "name": "Libra2 Explorer",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/hooks/usePageMetadata.ts
+++ b/src/components/hooks/usePageMetadata.ts
@@ -7,7 +7,7 @@ interface PageMetadataArgs {
 export function usePageMetadata(args: PageMetadataArgs = {}): void {
   useEffect(() => {
     document.title = args.title
-      ? `${args.title} | Aptos Explorer`
-      : "Aptos Explorer";
+      ? `${args.title} | Libra2 Explorer`
+      : "Libra2 Explorer";
   }, [args]);
 }

--- a/src/global-config/GlobalConfig.tsx
+++ b/src/global-config/GlobalConfig.tsx
@@ -21,7 +21,7 @@ import {
 } from "@aptos-labs/ts-sdk";
 
 const HEADERS = {
-  "x-indexer-client": "aptos-explorer",
+  "x-indexer-client": "libra2xp",
 };
 
 export type GlobalState = {

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
       <CoinToFAMigrationBanner />
       <WalletDeprecationBanner />
       <Typography variant="h3" component="h3" marginBottom={4}>
-        Aptos Explorer
+        Libra2 Explorer
       </Typography>
       <NetworkInfo isOnHomePage />
       <HeaderSearch />


### PR DESCRIPTION
## Summary
- rename project to Libra2XP and update user-facing text to Libra2 Explorer
- update manifest and redirects for Libra2 branding
- identify app to indexer as `libra2xp`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68baad9022088332bf6fb59138ab8474