### PR TITLE
feat: use Libra2 network endpoints

### DIFF
--- a/src/api/hooks/useGetNetworkChainIds.ts
+++ b/src/api/hooks/useGetNetworkChainIds.ts
@@ -20,9 +20,13 @@ export function useGetChainIdAndCache(networkName: NetworkName): string | null {
 
   const chainId = data?.chain_id ? data?.chain_id.toString() : null;
 
-  // cache network chain ids (except local) to `localStorage` to avoid refetching chain data
+  // cache network chain ids (except local networks) to `localStorage` to avoid refetching chain data
   // as the chain ids for those networks won't be changed very often
-  if (chainId !== null && networkName !== "local") {
+  if (
+    chainId !== null &&
+    networkName !== "local" &&
+    networkName !== "localnet"
+  ) {
     setLocalStorageWithExpiry(`${networkName}ChainId`, chainId, TTL);
   }
 

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -18,15 +18,14 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
 export function getGraphqlURI(networkName: NetworkName): string | undefined {
   switch (networkName) {
     case "mainnet":
-      return "https://api.mainnet.aptoslabs.com/v1/graphql";
+      return "https://mainnet.libra2.org/v1/graphql";
     case "testnet":
-      return "https://api.testnet.staging.aptoslabs.com/v1/graphql";
+      return "https://testnet.libra2.org/v1/graphql";
     case "devnet":
-      return "https://api.devnet.staging.aptoslabs.com/v1/graphql";
-    case "decibel":
-      return "https://api.netna.staging.aptoslabs.com/v1/graphql";
+      return "https://devnet.libra2.org/v1/graphql";
     case "local":
-      return "http://127.0.0.1:8090/v1/graphql";
+    case "localnet":
+      return "http://127.0.0.1:8080/v1/graphql";
     default:
       return undefined;
   }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -4,18 +4,17 @@ import {CoinDescription} from "./api/hooks/useGetCoinList";
  * Network
  */
 export const devnetUrl =
-  import.meta.env.APTOS_DEVNET_URL ||
-  "https://api.devnet.staging.aptoslabs.com/v1";
+  import.meta.env.VITE_DEVNET_URL || "https://devnet.libra2.org";
 
 export const networks: Record<string, string> = {
-  mainnet: "https://api.mainnet.aptoslabs.com/v1",
-  testnet: "https://api.testnet.staging.aptoslabs.com/v1",
+  mainnet: "https://mainnet.libra2.org",
+  testnet: "https://testnet.libra2.org",
   devnet: devnetUrl,
-  decibel: "https://api.netna.staging.aptoslabs.com/v1",
-  local: "http://127.0.0.1:8080/v1",
+  local: "http://127.0.0.1:8080",
+  localnet: "http://127.0.0.1:8080",
 };
 
-export const hiddenNetworks = ["decibel"];
+export const hiddenNetworks = ["localnet"];
 
 export type NetworkName = keyof typeof networks;
 
@@ -35,11 +34,11 @@ type ApiKeys = {
  * value to `undefined`.
  */
 const apiKeys: ApiKeys = {
-  mainnet: "AG-4SNLEBS1PFZ3PCMUCA3T3MW5WWF5JWLJX",
-  testnet: "AG-6ZFXBNIVINVKOKLNAHNTFPDHY8WMBBD3X",
-  devnet: "AG-GA6I9F6H8NM1ACW8ZVJGMPUTJUKZ5KN6A",
-  decibel: undefined,
+  mainnet: undefined,
+  testnet: undefined,
+  devnet: undefined,
   local: undefined,
+  localnet: undefined,
 };
 
 export function getApiKey(network_name: NetworkName): string | undefined {
@@ -54,7 +53,6 @@ export enum Network {
   MAINNET = "mainnet",
   TESTNET = "testnet",
   DEVNET = "devnet",
-  DECIBEL = "decibel",
 }
 
 // Remove trailing slashes


### PR DESCRIPTION
## Summary
- switch REST and GraphQL URLs to Libra2 networks
- add `localnet` alias and remove Aptos-only networks
- avoid caching chain IDs for local networks

## Testing
- `pnpm lint`
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_68bab65d8aa88332bcbfb86474ccbfd5