### PR TITLE
feat: REST fallback when indexer lacks GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ cp .env.example .env.local
 
 Supported variables:
 
-| Variable | Default |
-|----------|---------|
-| `LIBRA2_MAINNET_URL` | `https://mainnet.libra2.org` |
-| `LIBRA2_TESTNET_URL` | `https://testnet.libra2.org` |
-| `LIBRA2_DEVNET_URL` | `https://devnet.libra2.org` |
-| `LIBRA2_LOCAL_URL` | `http://127.0.0.1:8080` |
-| `LIBRA2_LOCALNET_URL` | `http://127.0.0.1:8080` |
+| Variable              | Default                      |
+| --------------------- | ---------------------------- |
+| `LIBRA2_MAINNET_URL`  | `https://mainnet.libra2.org` |
+| `LIBRA2_TESTNET_URL`  | `https://testnet.libra2.org` |
+| `LIBRA2_DEVNET_URL`   | `https://devnet.libra2.org`  |
+| `LIBRA2_LOCAL_URL`    | `http://127.0.0.1:8080`      |
+| `LIBRA2_LOCALNET_URL` | `http://127.0.0.1:8080`      |
+
+### GraphQL support
+
+Libra2's indexer does not yet provide the full GraphQL schema.
+When a GraphQL endpoint is unavailable the explorer temporarily
+falls back to REST endpoints, so some queries may be limited until
+native support is added.
 
 Build dependencies:
 

--- a/src/api/hooks/useGetAccountAllTransactions.ts
+++ b/src/api/hooks/useGetAccountAllTransactions.ts
@@ -1,4 +1,8 @@
 import {gql, useQuery as useGraphqlQuery} from "@apollo/client";
+import {useQuery} from "@tanstack/react-query";
+import {Types} from "aptos";
+import {useGlobalState} from "../../global-config/GlobalConfig";
+import {useGetIsGraphqlClientSupported} from "./useGraphqlClient";
 import {tryStandardizeAddress} from "../../utils";
 
 const ACCOUNT_TRANSACTIONS_COUNT_QUERY = gql`
@@ -20,17 +24,43 @@ export function useGetAccountAllTransactionCount(
   // whenever talking to the indexer, the address needs to fill in leading 0s
   // for example: 0x123 => 0x000...000123  (61 0s before 123)
   const addr64Hash = tryStandardizeAddress(address);
+  const [state] = useGlobalState();
+  const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
 
   const {loading, error, data} = useGraphqlQuery(
     ACCOUNT_TRANSACTIONS_COUNT_QUERY,
-    {variables: {address: addr64Hash}},
+    {variables: {address: addr64Hash}, skip: !isGraphqlClientSupported},
   );
 
-  if (!addr64Hash || loading || error || !data) {
-    return undefined;
+  const restQuery = useQuery({
+    queryKey: [
+      "account_all_transactions_count",
+      {addr64Hash},
+      state.network_value,
+    ],
+    queryFn: async () => {
+      if (!addr64Hash) {
+        return undefined;
+      }
+      const txns = await state.aptos_client.getAccountTransactions(addr64Hash, {
+        limit: 100,
+      });
+      return txns.length;
+    },
+    enabled: !isGraphqlClientSupported,
+  });
+
+  if (isGraphqlClientSupported) {
+    if (!addr64Hash || loading || error || !data) {
+      return undefined;
+    }
+    return data.move_resources_aggregate?.aggregate?.count;
   }
 
-  return data.move_resources_aggregate?.aggregate?.count;
+  if (restQuery.isLoading || restQuery.isError) {
+    return undefined;
+  }
+  return restQuery.data;
 }
 
 const ACCOUNT_TRANSACTIONS_QUERY = gql`
@@ -52,18 +82,46 @@ export function useGetAccountAllTransactionVersions(
   offset?: number,
 ): number[] {
   const addr64Hash = tryStandardizeAddress(address);
+  const [state] = useGlobalState();
+  const isGraphqlClientSupported = useGetIsGraphqlClientSupported();
 
   const {loading, error, data} = useGraphqlQuery(ACCOUNT_TRANSACTIONS_QUERY, {
     variables: {address: addr64Hash, limit: limit, offset: offset},
+    skip: !isGraphqlClientSupported,
   });
 
-  if (!addr64Hash || loading || error || !data) {
-    return [];
+  const restQuery = useQuery({
+    queryKey: [
+      "account_all_transactions_versions",
+      {addr64Hash, limit, offset},
+      state.network_value,
+    ],
+    queryFn: async () => {
+      if (!addr64Hash) {
+        return [];
+      }
+      const txns = await state.aptos_client.getAccountTransactions(addr64Hash, {
+        start: offset,
+        limit,
+      });
+      return txns.map((txn: Types.Transaction) => Number(txn.version));
+    },
+    enabled: !isGraphqlClientSupported,
+  });
+
+  if (isGraphqlClientSupported) {
+    if (!addr64Hash || loading || error || !data) {
+      return [];
+    }
+    return data.account_transactions.map(
+      (resource: {transaction_version: number}) => {
+        return resource.transaction_version;
+      },
+    );
   }
 
-  return data.account_transactions.map(
-    (resource: {transaction_version: number}) => {
-      return resource.transaction_version;
-    },
-  );
+  if (restQuery.isLoading || restQuery.isError || !restQuery.data) {
+    return [];
+  }
+  return restQuery.data;
 }


### PR DESCRIPTION
## Summary
- use REST API when indexer GraphQL endpoints are unsupported
- document limited GraphQL support and fallback behavior

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb0e940574833286b29dd7ba1c0a25