### PR TITLE
feat: add AI agent view placeholder

### DIFF
--- a/src/ExplorerRoutes.tsx
+++ b/src/ExplorerRoutes.tsx
@@ -18,6 +18,7 @@ const EnhancedValidatorsPage = lazy(
 );
 const ValidatorPage = lazy(() => import("./pages/DelegatoryValidator"));
 const AnalyticsPage = lazy(() => import("./pages/Analytics/Index"));
+const AIAgentViewPage = lazy(() => import("./pages/AIAgentView/Index"));
 
 export default function ExplorerRoutes() {
   return (
@@ -90,6 +91,7 @@ export default function ExplorerRoutes() {
           />
         </Route>
         <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/ai-agent-view" element={<AIAgentViewPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </ExplorerLayout>

--- a/src/pages/AIAgentView/Index.tsx
+++ b/src/pages/AIAgentView/Index.tsx
@@ -1,0 +1,17 @@
+import {Box, Typography} from "@mui/material";
+import * as React from "react";
+import PageHeader from "../layout/PageHeader";
+import {usePageMetadata} from "../../components/hooks/usePageMetadata";
+
+export default function AIAgentViewPage() {
+  usePageMetadata({title: "AI Agent View"});
+  return (
+    <Box>
+      <PageHeader />
+      <Typography variant="h3" marginBottom={2}>
+        AI Agent View
+      </Typography>
+      <Typography>Coming Soon — Agent Behavior Viewer.</Typography>
+    </Box>
+  );
+}

--- a/src/pages/layout/Nav.tsx
+++ b/src/pages/layout/Nav.tsx
@@ -68,6 +68,11 @@ export default function Nav() {
         label="Validators"
       />
       <NavButton to="/blocks" title="View Latest Blocks" label="Blocks" />
+      <NavButton
+        to="/ai-agent-view"
+        title="View AI Agent Behavior"
+        label="AI Agent View"
+      />
     </Box>
   );
 }

--- a/src/pages/layout/NavMobile.tsx
+++ b/src/pages/layout/NavMobile.tsx
@@ -91,6 +91,9 @@ export default function NavMobile() {
         <MenuItem onClick={() => handleCloseAndNavigate("/blocks")}>
           Blocks
         </MenuItem>
+        <MenuItem onClick={() => handleCloseAndNavigate("/ai-agent-view")}>
+          AI Agent View
+        </MenuItem>
         <Divider />
         <WalletConnector
           networkSupport={state.network_name}


### PR DESCRIPTION
## Summary
- add placeholder AI Agent View page
- wire up AI Agent View route
- add AI Agent View to navigation menus

## Testing
- `pnpm lint` *(fails: Property 'version' does not exist on type 'Transaction$1')*
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68bb14587eb88332bb8362e8efed61f5