### PR TITLE
fix: handle pending transactions when extracting version

### DIFF
--- a/src/api/hooks/useGetAccountAllTransactions.ts
+++ b/src/api/hooks/useGetAccountAllTransactions.ts
@@ -104,7 +104,12 @@ export function useGetAccountAllTransactionVersions(
         start: offset,
         limit,
       });
-      return txns.map((txn: Types.Transaction) => Number(txn.version));
+      return txns
+        .filter(
+          (txn): txn is Types.Transaction & {version: string} =>
+            "version" in txn,
+        )
+        .map((txn) => Number(txn.version));
     },
     enabled: !isGraphqlClientSupported,
   });


### PR DESCRIPTION
## Summary
- filter account transactions to ignore pending txns when collecting versions

## Testing
- `pnpm lint`
- `pnpm vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bb1fdbf3f8833280a4633ae3a9a97c