### PR TITLE
fix(coins): fallback metadata; LBT via v1 CoinInfo REST backup

### DIFF
--- a/src/api/hooks/useGetAccountAPTBalance.ts
+++ b/src/api/hooks/useGetAccountAPTBalance.ts
@@ -1,15 +1,45 @@
 import {Types} from "aptos";
 import {useQuery} from "@tanstack/react-query";
-import {ResponseError} from "../client";
-import {getBalance} from "../index";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 
-export function useGetAccountAPTBalance(address: Types.Address) {
+export function useGetAccountAPTBalance(
+  address: Types.Address,
+  coinType?: `0x${string}::${string}::${string}`, // 可选：要查的币，不传=APT
+) {
   const [state] = useGlobalState();
-  // TODO: Convert all Types.Address to AccountAddress
-  return useQuery<string, ResponseError>({
-    queryKey: ["aptBalance", {address}, state.network_value],
-    queryFn: () => getBalance(state.sdk_v2_client, address),
+
+  return useQuery<string, Error>({
+    queryKey: ["coinBalance_rawView", {address, coinType}, state.network_value],
     retry: false,
+    queryFn: async () => {
+      const type = coinType ?? ("0x1::aptos_coin::AptosCoin" as const);
+
+      // 取 REST 基地址（按你项目字段来，兜底到本地 8080）
+      const baseUrl =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (state as any)?.network_value?.api_url ??
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (state as any)?.network_value?.node_url ??
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (state as any)?.sdk_v2_client?.config?.client?.baseUrl ??
+        "http://127.0.0.1:8080";
+
+      const resp = await fetch(`${baseUrl}/v1/view`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          function: "0x1::coin::balance",
+          type_arguments: [type],
+          arguments: [address],
+        }),
+      });
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status} when calling /v1/view`);
+      }
+      const json = await resp.json();
+      // /v1/view 返回形如 ["100000000"]
+      const val = Array.isArray(json) ? json[0] : "0";
+      return (val ?? "0").toString();
+    },
   });
 }

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -25,7 +25,7 @@ export function getGraphqlURI(networkName: NetworkName): string | undefined {
       return "https://devnet.libra2.org/v1/graphql";
     case "local":
     case "localnet":
-      return "http://127.0.0.1:8080/v1/graphql";
+      return "http://127.0.0.1:8090/v1/graphql";
     default:
       return undefined;
   }

--- a/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
+++ b/src/components/IndividualPageContent/ContentValue/CurrencyValue.tsx
@@ -91,7 +91,7 @@ export function APTCurrencyValue({
   return (
     <CurrencyValue
       {...{amount, decimals, fixedDecimalPlaces}}
-      currencyCode="APT"
+      currencyCode="LBT"
     />
   );
 }

--- a/src/pages/Account/BalanceCard.tsx
+++ b/src/pages/Account/BalanceCard.tsx
@@ -12,71 +12,100 @@ import {OpenInNew} from "@mui/icons-material";
 
 type BalanceCardProps = {
   address: string;
+  coinType?: `0x${string}::${string}::${string}`; // 新
+  symbol?: string;                                 // 新
+  decimals?: number;                               // 新，默认 8
 };
 
-export default function BalanceCard({address}: BalanceCardProps) {
-  const balance = useGetAccountAPTBalance(address);
+export default function BalanceCard({
+  address,
+  coinType,
+  symbol,
+  decimals = 8,
+}: BalanceCardProps) {
+  const APT = "0x1::aptos_coin::AptosCoin" as const;
+  const theType = coinType ?? APT;
+  const isAPT = theType === APT;
+
+  // 查询余额（已支持任意 coinType）
+  const balance = useGetAccountAPTBalance(address, theType);
+
   const [globalState] = useGlobalState();
   const [price, setPrice] = useState<number | null>(null);
 
   useEffect(() => {
-    const fetchPrice = async () => {
-      try {
-        const fetchedPrice = await getPrice();
-        setPrice(fetchedPrice);
-      } catch (error) {
-        console.error("Error fetching APT price:", error);
-        setPrice(null);
-      }
-    };
+    if (!isAPT) { setPrice(null); return; }    // 非 APT 不取价
+    (async () => {
+      try { setPrice(await getPrice()); } catch { setPrice(null); }
+    })();
+  }, [isAPT]);
 
-    fetchPrice();
-  }, []);
-
+  const sym = symbol ?? (isAPT ? "APT" : "LBT");
   const balanceUSD =
-    balance.data && price !== null
-      ? (Number(balance.data) * Number(price)) / 10e7
+    isAPT && balance.data && price !== null
+      ? (Number(balance.data) * Number(price)) / 1e8
       : null;
 
-  return balance.data ? (
+  // ——从这里开始：无论如何都渲染，便于你看到加载/报错原因——
+  return (
     <Card height="auto">
       <Stack spacing={1.5} marginY={1}>
-        {/* APT balance */}
-        <Typography fontSize={17} fontWeight={700}>
-          {`${getFormattedBalanceStr(balance.data)} APT`}
+        {/* 临时调试：看 coinType 和状态 */}
+        <Typography fontSize={12} color={grey[450]}>
+          coinType: {theType}
         </Typography>
-
-        {/* USD value */}
-        {globalState.network_name === "mainnet" && balanceUSD !== null && (
-          <Typography fontSize={14} color={grey[450]}>
-            ${balanceUSD.toLocaleString(undefined, {maximumFractionDigits: 2})}{" "}
-            USD
+        {balance.isLoading && (
+          <Typography fontSize={14} color={grey[450]}>Loading balance…</Typography>
+        )}
+        {balance.error && (
+          <Typography fontSize={12} color="error.main">
+            {String((balance.error as any)?.message ?? balance.error)}
           </Typography>
         )}
 
+        {/* 主余额（拿到 data 才显示数值） */}
+        {balance.data && (
+          <>
+            <Typography fontSize={17} fontWeight={700}>
+              {`${getFormattedBalanceStr(balance.data, decimals as any)} ${sym}`}
+            </Typography>
+
+            {isAPT && globalState.network_name === "mainnet" && balanceUSD !== null && (
+              <Typography fontSize={14} color={grey[450]}>
+                ${balanceUSD.toLocaleString(undefined, {maximumFractionDigits: 2})} USD
+              </Typography>
+            )}
+          </>
+        )}
+
         <Stack direction="row" spacing={1} alignItems="center">
-          <Typography fontSize={12} color={grey[450]}>
-            Balance
-          </Typography>
+          <Typography fontSize={12} color={grey[450]}>Balance</Typography>
           <StyledTooltip
-            title={`This balance reflects the amount of APT tokens held in your wallet${globalState.network_name === "mainnet" ? ` and their live value in USD at a rate of 1 APT = $${price?.toFixed(2)}` : ""}.`}
+            title={`This balance reflects the amount of ${sym} tokens held in your wallet${
+              isAPT && globalState.network_name === "mainnet"
+                ? ` and their live value in USD at a rate of 1 APT = $${price?.toFixed(2)}`
+                : ""
+            }.`}
           >
             <InfoOutlinedIcon sx={{fontSize: 15, color: grey[450]}} />
           </StyledTooltip>
         </Stack>
 
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Link
-            href={`https://aptos.lightscan.one/portfolio/${address}`}
-            underline="none"
-            fontSize={12}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            DeFi positions on Lightscan <OpenInNew sx={{fontSize: 12}} />
-          </Link>
-        </Stack>
+        {/* Lightscan 链接只对 APT 有意义 */}
+        {isAPT && (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Link
+              href={`https://aptos.lightscan.one/portfolio/${address}`}
+              underline="none"
+              fontSize={12}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              DeFi positions on Lightscan <OpenInNew sx={{fontSize: 12}} />
+            </Link>
+          </Stack>
+        )}
       </Stack>
     </Card>
-  ) : null;
+  );
 }

--- a/src/pages/Account/Index.tsx
+++ b/src/pages/Account/Index.tsx
@@ -191,7 +191,12 @@ export default function AccountPage({
         />
       </Grid>
       <Grid size={{xs: 12, md: 4, lg: 3}} marginTop={{md: 0, xs: 2}}>
-        <BalanceCard address={address} />
+        <BalanceCard
+          address={address}
+          coinType={"0x1::libra2_coin::Libra2Coin"} // 你的 LBT 类型
+          symbol="LBT"
+          decimals={8}
+        />
       </Grid>
       <Grid size={{xs: 12, md: 8, lg: 12}} marginTop={4} alignSelf="center">
         {state.network_name === Network.MAINNET && <AptosNamesBanner />}

--- a/src/pages/Account/Tabs.tsx
+++ b/src/pages/Account/Tabs.tsx
@@ -22,7 +22,7 @@ import {useParams} from "react-router-dom";
 import {useNavigate} from "../../routing";
 import {accountPagePath} from "./Index";
 
-const TAB_VALUES: TabValue[] = ["transactions", "resources", "modules", "info"];
+const TAB_VALUES: TabValue[] = ["transactions", "coins", "tokens", "multisig", "resources", "modules", "info"];
 
 const TabComponents = Object.freeze({
   transactions: TransactionsTab,

--- a/src/pages/Account/Tabs/CoinsTab.tsx
+++ b/src/pages/Account/Tabs/CoinsTab.tsx
@@ -10,6 +10,37 @@ import {useGetAccountCoins} from "../../../api/hooks/useGetAccountCoins";
 import {coinOrderIndex} from "../../utils";
 import {Types} from "aptos";
 
+// ===== 兜底元数据常量 =====
+const LBT_TYPE = "0x1::libra2_coin::Libra2Coin";
+const DEFAULT_DECIMALS = 8;
+
+type TokenStandard = "v1" | "v2";
+
+type SimpleMeta = {
+  name: string;
+  symbol: string;
+  decimals: number;
+  token_standard: TokenStandard;
+};
+
+// 根据 asset_type 生成最小可用的元数据
+function buildFallbackMeta(assetType: string): SimpleMeta {
+  const isTypeTag = assetType.includes("::");
+  // ✅ 显式标注类型，别对三元表达式用 `as const`
+  const token_standard: TokenStandard = isTypeTag ? "v1" : "v2";
+
+  let name = assetType;
+  let symbol = isTypeTag ? (assetType.split("::").pop() ?? "UNKNOWN") : "UNKNOWN";
+
+  // LBT 专用兜底
+  if (assetType === LBT_TYPE) {
+    name = "Libra2 Coin";
+    symbol = "LBT";
+  }
+
+  return { name, symbol, decimals: DEFAULT_DECIMALS, token_standard };
+}
+
 type TokenTabsProps = {
   address: string;
   resourceData: Types.MoveResource[] | undefined;
@@ -35,75 +66,70 @@ export default function CoinsTab({address, resourceData}: TokenTabsProps) {
     return <EmptyTabContent />;
   }
 
-  function parse_coins(): CoinDescriptionPlusAmount[] {
-    if (!coins || coins.length <= 0) {
-      return [];
-    }
-    return coins
-      .filter((coin) => Boolean(coin.metadata))
-      .map((coin): CoinDescriptionPlusAmount => {
-        const foundCoin = findCoinData(coinData?.data ?? [], coin.asset_type);
+function parse_coins(): CoinDescriptionPlusAmount[] {
+  if (!coins || coins.length <= 0) return [];
 
-        if (!foundCoin) {
-          // Minimally, return the information we do know
-          return {
-            name: coin.metadata.name,
-            amount: coin.amount,
-            decimals: coin.metadata.decimals,
-            symbol: coin.metadata.symbol,
-            assetType: coin.asset_type,
-            assetVersion: coin.metadata.token_standard,
-            chainId: 0,
-            tokenAddress:
-              coin.metadata.token_standard === "v1" ? coin.asset_type : null,
-            faAddress:
-              coin.metadata.token_standard === "v2" ? coin.asset_type : null,
-            bridge: null,
-            panoraSymbol: null,
-            logoUrl: "",
-            websiteUrl: null,
-            category: "N/A",
-            isInPanoraTokenList: false,
-            isBanned: false,
-            panoraOrderIndex: 20000000,
-            coinGeckoId: null,
-            coinMarketCapId: null,
-            tokenStandard: coin.metadata.token_standard,
-            usdPrice: null,
-            panoraTags: [],
-            panoraUI: false,
-            native: false,
-            usdValue: 0,
-          };
-        } else {
-          // Otherwise, use the stuff found in the lookup
-          return {
-            ...foundCoin,
-            amount: coin.amount,
-            tokenStandard: coin.metadata.token_standard,
-            usdValue: foundCoin.usdPrice
-              ? Math.round(
-                  100 *
-                    (Number.EPSILON +
-                      (parseFloat(foundCoin.usdPrice) * coin.amount) /
-                        10 ** coin.metadata.decimals),
-                ) / 100
-              : null,
-            assetType: coin.asset_type,
-            assetVersion: coin.metadata.token_standard,
-          };
-        }
-      })
-      .sort((a, b) => {
-        return (
-          coinOrderIndex(a as CoinDescription) -
-          coinOrderIndex(b as CoinDescription)
-        );
-      })
-      .sort((a, b) => {
-        return (b.usdValue ?? -1) - (a.usdValue ?? -1);
-      });
-  }
+  return coins
+    .map((coin): CoinDescriptionPlusAmount => {
+      // 有 metadata 用它；没有就用兜底
+      const md = coin.metadata ?? buildFallbackMeta(coin.asset_type);
+
+      // 白名单/价格/Logo 等扩展信息
+      const foundCoin = findCoinData(coinData?.data ?? [], coin.asset_type);
+
+      if (!foundCoin) {
+        // 最小信息也能渲染出来
+        return {
+          name: md.name || coin.asset_type,
+          amount: coin.amount,
+          decimals: md.decimals,
+          symbol: md.symbol,
+          assetType: coin.asset_type,
+          assetVersion: md.token_standard,
+          chainId: 0,
+          tokenAddress: md.token_standard === "v1" ? coin.asset_type : null,
+          faAddress: md.token_standard === "v2" ? coin.asset_type : null,
+          bridge: null,
+          panoraSymbol: null,
+          logoUrl: "",
+          websiteUrl: null,
+          category: "N/A",
+          isInPanoraTokenList: false,
+          isBanned: false,
+          panoraOrderIndex: 20000000,
+          coinGeckoId: null,
+          coinMarketCapId: null,
+          tokenStandard: md.token_standard,
+          usdPrice: null,
+          panoraTags: [],
+          panoraUI: false,
+          native: coin.asset_type === LBT_TYPE,
+          usdValue: 0,
+        };
+      } else {
+        // 找到了更丰富的资料，合并并计算 USD 价值
+        return {
+          ...foundCoin,
+          amount: coin.amount,
+          tokenStandard: md.token_standard,
+          assetType: coin.asset_type,
+          assetVersion: md.token_standard,
+          usdValue: foundCoin.usdPrice
+            ? Math.round(
+                100 *
+                  (Number.EPSILON +
+                    (parseFloat(foundCoin.usdPrice) * coin.amount) /
+                      10 ** md.decimals),
+              ) / 100
+            : null,
+        };
+      }
+    })
+    // 先按你们的优先级排序
+    .sort((a, b) => coinOrderIndex(a as CoinDescription) - coinOrderIndex(b as CoinDescription))
+    // 再按 USD 价值降序
+    .sort((a, b) => (b.usdValue ?? -1) - (a.usdValue ?? -1));
+}
 
   return (
     <CoinsTable


### PR DESCRIPTION
### Description
Coins tab dropped rows when `metadata == null` on local networks (LBT case).
Add fallback metadata so LBT shows up even if indexer metadata is missing.

### Changes
- CoinsTab: remove metadata filter; add fallback metadata (LBT: name "Libra2 Coin", symbol "LBT", decimals 8)
- (Optional) keep REST CoinInfo<T> fallback path

### Testing
- Fullnode: http://127.0.0.1:8080
- Indexer:  http://127.0.0.1:8090/v1/graphql
- Verified LBT displays with correct decimals on Coins tab.

### Checklist
- [ ] Build & lint pass locally
- [ ] No secrets / `.env.local` included