### PR TITLE
Handle indexer unavailable errors

### DIFF
--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -43,6 +43,15 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
+    case ResponseErrorType.INDEXER_UNAVAILABLE:
+      return (
+        <Alert severity="error">
+          The indexer service for this network is currently unavailable. This
+          can happen if the indexer reader process is not running or is still
+          catching up. Please start the indexer service for the network or try
+          again later.
+        </Alert>
+      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/Coin/Error.tsx
+++ b/src/pages/Coin/Error.tsx
@@ -40,6 +40,13 @@ export default function Error({error, struct}: ErrorProps) {
           </Alert>
         );
       }
+    case ResponseErrorType.INDEXER_UNAVAILABLE:
+      return (
+        <Alert severity="error">
+          The indexer service for this network is currently unavailable. Please
+          ensure it is running or try again later once it has caught up.
+        </Alert>
+      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/FungibleAsset/Error.tsx
+++ b/src/pages/FungibleAsset/Error.tsx
@@ -40,6 +40,13 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
+    case ResponseErrorType.INDEXER_UNAVAILABLE:
+      return (
+        <Alert severity="error">
+          The indexer service for this network is currently unavailable. Please
+          ensure it is running or try again later once it has caught up.
+        </Alert>
+      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">


### PR DESCRIPTION
## Summary
- detect indexer reader outages and raise a dedicated error type
- surface clearer guidance when the indexer backend is unavailable on account, coin, and fungible asset pages

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5b30bdfc8332a8272b32c5e8ef3d)