### PR TITLE
Fix indexer error message handling

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -25,7 +25,7 @@ export async function withResponseError<T>(promise: Promise<T>): Promise<T> {
         throw {type: ResponseErrorType.NOT_FOUND};
       }
     }
-    if (message?.toLowerCase().includes("indexer reader doesn't exist")) {
+    if (errorMessage?.toLowerCase().includes("indexer reader doesn't exist")) {
       throw {
         type: ResponseErrorType.INDEXER_UNAVAILABLE,
         message:


### PR DESCRIPTION
## Summary
- ensure indexer reader error detection uses the computed error message string

## Testing
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b707af9c88332b2877cd192a8f3a2)