### PR TITLE
Route account indexer reads to Indexer GraphQL and show friendly degraded state

### DIFF
--- a/src/api/hooks/useGetAccountModule.ts
+++ b/src/api/hooks/useGetAccountModule.ts
@@ -1,8 +1,28 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountModule} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountModuleResponse = {
+  move_modules: Array<{
+    bytecode: string;
+    abi?: Types.MoveModule;
+  }>;
+};
+
+const ACCOUNT_MODULE_QUERY = `
+  query AccountModule($address: String, $name: String) {
+    move_modules(
+      where: {address: {_eq: $address}, name: {_eq: $name}}
+      limit: 1
+    ) {
+      bytecode
+      abi
+    }
+  }
+`;
 
 export function useGetAccountModule(
   address: string,
@@ -12,7 +32,28 @@ export function useGetAccountModule(
 
   return useQuery<Types.MoveModuleBytecode, ResponseError>({
     queryKey: ["accountModule", {address, moduleName}, state.network_value],
-    queryFn: () => getAccountModule({address, moduleName}, state.aptos_client),
+    queryFn: async () => {
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountModuleResponse>(
+        state.network_name,
+        ACCOUNT_MODULE_QUERY,
+        {address: standardized, name: moduleName},
+      );
+      const module = data.move_modules[0];
+      if (!module) {
+        throw {type: ResponseErrorType.NOT_FOUND};
+      }
+      return {
+        bytecode: module.bytecode,
+        abi: module.abi,
+      };
+    },
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountModules.ts
+++ b/src/api/hooks/useGetAccountModules.ts
@@ -1,8 +1,25 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountModules} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountModulesResponse = {
+  move_modules: Array<{
+    bytecode: string;
+    abi?: Types.MoveModule;
+  }>;
+};
+
+const ACCOUNT_MODULES_QUERY = `
+  query AccountModules($address: String) {
+    move_modules(where: {address: {_eq: $address}}) {
+      bytecode
+      abi
+    }
+  }
+`;
 
 export function useGetAccountModules(
   address: string,
@@ -11,6 +28,23 @@ export function useGetAccountModules(
 
   return useQuery<Array<Types.MoveModuleBytecode>, ResponseError>({
     queryKey: ["accountModules", {address}, state.network_value],
-    queryFn: () => getAccountModules({address}, state.aptos_client),
+    queryFn: async () => {
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountModulesResponse>(
+        state.network_name,
+        ACCOUNT_MODULES_QUERY,
+        {address: standardized},
+      );
+      return data.move_modules.map((module) => ({
+        bytecode: module.bytecode,
+        abi: module.abi,
+      }));
+    },
   });
 }

--- a/src/api/hooks/useGetAccountResource.ts
+++ b/src/api/hooks/useGetAccountResource.ts
@@ -1,9 +1,29 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountResource} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {orderBy} from "lodash";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountResourceResponse = {
+  move_resources: Array<{
+    type: string;
+    data: Types.MoveResource["data"];
+  }>;
+};
+
+const ACCOUNT_RESOURCE_QUERY = `
+  query AccountResource($address: String, $type: String) {
+    move_resources(
+      where: {address: {_eq: $address}, type: {_eq: $type}}
+      limit: 1
+    ) {
+      type
+      data
+    }
+  }
+`;
 
 export type ModuleMetadata = {
   name: string;
@@ -42,10 +62,26 @@ export function useGetAccountResource(
       if (!address) {
         throw new Error("Address is undefined");
       }
-      return await getAccountResource(
-        {address, resourceType: resource},
-        state.aptos_client,
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountResourceResponse>(
+        state.network_name,
+        ACCOUNT_RESOURCE_QUERY,
+        {address: standardized, type: resource},
       );
+      const resourceData = data.move_resources[0];
+      if (!resourceData) {
+        throw {type: ResponseErrorType.NOT_FOUND};
+      }
+      return {
+        type: resourceData.type,
+        data: resourceData.data,
+      };
     },
     refetchOnWindowFocus: false,
   });

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -17,7 +17,10 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
 
 function getIndexerBaseUrl(networkName: NetworkName): string | undefined {
   const defaultIndexer =
-    import.meta.env.VITE_LIBRA2_INDEXER_HTTP ?? "https://indexer.libra2.org";
+    import.meta.env.VITE_INDEXER_URL ??
+    import.meta.env.INDEXER_URL ??
+    import.meta.env.VITE_LIBRA2_INDEXER_HTTP ??
+    "https://indexer.libra2.org";
 
   if (networkName === "local" || networkName === "localnet") {
     return (

--- a/src/api/indexerGraphql.ts
+++ b/src/api/indexerGraphql.ts
@@ -1,0 +1,71 @@
+import {getApiKey, NetworkName} from "../constants";
+import {
+  createIndexerUnavailableError,
+  isIndexerUnavailableMessage,
+  ResponseErrorType,
+} from "./client";
+import {getGraphqlURI} from "./hooks/useGraphqlClient";
+
+type GraphqlError = {
+  message?: string;
+};
+
+type GraphqlResponse<T> = {
+  data?: T;
+  errors?: GraphqlError[];
+};
+
+function buildIndexerUnavailableError(message?: string) {
+  if (isIndexerUnavailableMessage(message)) {
+    return createIndexerUnavailableError();
+  }
+  return {
+    type: ResponseErrorType.UNHANDLED,
+    message,
+  };
+}
+
+export async function fetchIndexerGraphql<T>(
+  networkName: NetworkName,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const graphqlUrl = getGraphqlURI(networkName);
+  if (!graphqlUrl) {
+    throw createIndexerUnavailableError();
+  }
+
+  const apiKey = getApiKey(networkName);
+  let response: Response;
+  try {
+    response = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(apiKey ? {authorization: `Bearer ${apiKey}`} : {}),
+      },
+      body: JSON.stringify({query, variables}),
+    });
+  } catch {
+    throw createIndexerUnavailableError();
+  }
+
+  const payload = (await response.json()) as GraphqlResponse<T>;
+  if (!response.ok) {
+    const message =
+      payload?.errors?.map((entry) => entry.message).join(" ") ??
+      response.statusText;
+    throw buildIndexerUnavailableError(message);
+  }
+
+  if (payload.errors?.length) {
+    const message = payload.errors.map((entry) => entry.message).join(" ");
+    throw buildIndexerUnavailableError(message);
+  }
+
+  if (!payload.data) {
+    throw buildIndexerUnavailableError("Indexer response missing data.");
+  }
+
+  return payload.data;
+}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,7 +1,7 @@
 import {CoinDescription} from "./api/hooks/useGetCoinList";
 
 const DEFAULT_NETWORK_URLS = {
-  mainnet: "https://mainnet.libra2.org/v1",
+  mainnet: "https://rpc.libra2.org/v1",
   testnet: "https://testnet.libra2.org/v1",
   devnet: "https://devnet.libra2.org/v1",
   local: "http://127.0.0.1:8080/v1",
@@ -19,6 +19,8 @@ function normalizeUrl(url?: string, fallback?: string) {
 export const networks: Record<string, string> = {
   mainnet: normalizeUrl(
     import.meta.env.LIBRA2_MAINNET_URL ??
+      import.meta.env.VITE_NODE_REST_URL ??
+      import.meta.env.NODE_REST_URL ??
       import.meta.env.VITE_LIBRA2_NODE_URL ??
       DEFAULT_NETWORK_URLS.mainnet,
     DEFAULT_NETWORK_URLS.mainnet,

--- a/src/pages/Account/Components/AccountAllTransactions.tsx
+++ b/src/pages/Account/Components/AccountAllTransactions.tsx
@@ -8,6 +8,11 @@ import {
   useGetAccountAllTransactionVersions,
 } from "../../../api/hooks/useGetAccountAllTransactions";
 import {useLogEventWithBasic} from "../hooks/useLogEventWithBasic";
+import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../api/client";
 
 function RenderPagination({
   currentPage,
@@ -70,11 +75,22 @@ export function AccountAllTransactionsWithPagination({
     offset,
   );
 
+  if (versions.error?.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+    return (
+      <EmptyTabContent
+        message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+      />
+    );
+  }
+
   return (
     <>
       <Stack spacing={2}>
         <Box sx={{width: "auto", overflowX: "auto"}}>
-          <UserTransactionsTable versions={versions} address={address} />
+          <UserTransactionsTable
+            versions={versions.versions}
+            address={address}
+          />
         </Box>
         {numPages > 1 && (
           <Box sx={{display: "flex", justifyContent: "center"}}>
@@ -93,7 +109,16 @@ type AccountAllTransactionsProps = {
 export default function AccountAllTransactions({
   address,
 }: AccountAllTransactionsProps) {
-  let txnCount = useGetAccountAllTransactionCount(address);
+  const txnCountResponse = useGetAccountAllTransactionCount(address);
+  if (txnCountResponse.error?.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+    return (
+      <EmptyTabContent
+        message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+      />
+    );
+  }
+
+  let txnCount = txnCountResponse.count;
   let canSeeAll = true;
 
   if (txnCount === undefined) {

--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -26,11 +30,9 @@ export default function Error({error, address}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -52,15 +54,6 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. This
-          can happen if the indexer reader process is not running or is still
-          catching up. Please start the indexer service for the network or try
-          again later.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -43,6 +43,10 @@ import {encodeInputArgsForViewRequest, sortPetraFirst} from "../../../../utils";
 import {accountPagePath} from "../../Index";
 import {parseTypeTag} from "@aptos-labs/ts-sdk";
 import {WalletDeprecationBanner} from "../../../../components/WalletDeprecationBanner";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../../api/client";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -82,6 +86,13 @@ function Contract({
   }
 
   if (error) {
+    if (error.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+      return (
+        <EmptyTabContent
+          message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+        />
+      );
+    }
     return <Error address={address} error={error} />;
   }
 

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -25,6 +25,10 @@ import {useNavigate} from "../../../../routing";
 import SidebarItem from "../../Components/SidebarItem";
 import {Code} from "../../Components/CodeSnippet";
 import {accountPagePath} from "../../Index";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../../api/client";
 
 interface ModuleSidebarProps {
   sortedPackages: PackageMetadata[];
@@ -242,6 +246,13 @@ function ABI({address, moduleName}: {address: string; moduleName: string}) {
   }
 
   if (error) {
+    if (error.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+      return (
+        <EmptyTabContent
+          message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+        />
+      );
+    }
     return <Error address={address} error={error} />;
   }
 

--- a/src/pages/Coin/Error.tsx
+++ b/src/pages/Coin/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -24,11 +28,9 @@ export default function Error({error, struct}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -49,13 +51,6 @@ export default function Error({error, struct}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. Please
-          ensure it is running or try again later once it has caught up.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/FungibleAsset/Error.tsx
+++ b/src/pages/FungibleAsset/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -24,11 +28,9 @@ export default function Error({error, address}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -49,13 +51,6 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. Please
-          ensure it is running or try again later once it has caught up.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">


### PR DESCRIPTION
### Motivation
- The node REST `/v1/accounts/:address/resources` can return internal DB indexer errors when the node does not expose the internal indexer reader, causing red error messages in the Explorer UI. The Explorer must use the external indexer endpoint for rich account queries and avoid rendering raw internal indexer error strings to users.

### Description
- Add a small Indexer GraphQL fetch helper `fetchIndexerGraphql` (`src/api/indexerGraphql.ts`) and route account queries (resources, single resource, modules, single module) to the indexer GraphQL instead of calling the node REST endpoints in the account hooks (`src/api/hooks/*` updates).
- Improve indexer-unavailable detection and centralize the user-facing message (`src/api/client.ts`) to suppress raw DB indexer error text and return a typed `INDEXER_UNAVAILABLE` error with a friendly message.
- Make UI components gracefully degrade: account transaction listing, modules, and resource panels now show a neutral empty/degraded state with the friendly guidance message rather than raw errors (`src/pages/Account/*`, `src/pages/Coin/Error.tsx`, `src/pages/FungibleAsset/Error.tsx`, and account transactions components).
- Add env/config support and reasonable defaults so the app uses separate endpoints: `NODE_REST_URL` / `VITE_NODE_REST_URL` for RPC (mainnet default changed to `https://rpc.libra2.org/v1`) and `INDEXER_URL` / `VITE_INDEXER_URL` for the indexer (default `https://indexer.libra2.org`) (`src/constants.tsx`, `src/api/hooks/useGraphqlClient.tsx`).

### Testing
- Ran formatting and linting hooks (`prettier` and `eslint --fix`) as part of the pre-commit tasks and they completed successfully after a small fix to the new helper, with no outstanding lint errors.
- Started the dev server (`pnpm exec vite --host 0.0.0.0 --port 4173`) and confirmed the app served (Vite ready) and rendered the account page; a headless browser screenshot of `/account/0x1` was captured to verify the UI renders the account page without the raw DB indexer error.
- Manual verification checklist executed locally: loading `/account/<addr>?network=mainnet` shows no raw "DB indexer reader is not available" text, modules/resources/transactions now use the indexer GraphQL and show a neutral empty state when the indexer is unavailable, and balances/view-function calls still use the RPC and continue to work.

Validation commands
- Install & run: `pnpm install` and `pnpm exec vite --host 0.0.0.0 --port 4173`.
- Dev checks: open `http://localhost:4173/account/<address>?network=mainnet` to confirm behavior.
- Env configuration: set `INDEXER_URL` / `VITE_INDEXER_URL` to the indexer HTTP base and `NODE_REST_URL` / `VITE_NODE_REST_URL` to the node RPC base to verify mainnet presets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef067bfac8332948262638e8c1683)