### PR TITLE
Fix indexer GraphQL URL handling, add indexer error detection & validators fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Example environment configuration for network endpoints
-LIBRA2_MAINNET_URL=https://mainnet.libra2.org
-LIBRA2_TESTNET_URL=https://testnet.libra2.org
-LIBRA2_DEVNET_URL=https://devnet.libra2.org
-LIBRA2_LOCAL_URL=http://127.0.0.1:8080
-LIBRA2_LOCALNET_URL=http://127.0.0.1:8080
+NODE_REST_URL=https://rpc.libra2.org/v1
+INDEXER_URL=https://indexer.libra2.org
+LIBRA2_TESTNET_URL=https://testnet.libra2.org/v1
+LIBRA2_DEVNET_URL=https://devnet.libra2.org/v1
+LIBRA2_LOCAL_URL=http://127.0.0.1:8080/v1
+LIBRA2_LOCALNET_URL=http://127.0.0.1:8080/v1

--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,6 @@
-LIBRA2_MAINNET_URL=https://mainnet.libra2.org
-LIBRA2_TESTNET_URL=https://testnet.libra2.org
-LIBRA2_DEVNET_URL=https://devnet.libra2.org
-LIBRA2_LOCAL_URL=http://127.0.0.1:8080
-LIBRA2_LOCALNET_URL=http://127.0.0.1:8080
+NODE_REST_URL=https://rpc.libra2.org/v1
+INDEXER_URL=https://indexer.libra2.org
+LIBRA2_TESTNET_URL=https://testnet.libra2.org/v1
+LIBRA2_DEVNET_URL=https://devnet.libra2.org/v1
+LIBRA2_LOCAL_URL=http://127.0.0.1:8080/v1
+LIBRA2_LOCALNET_URL=http://127.0.0.1:8080/v1

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,5 @@ src/assets/svg/aptos_explorer_svg.zip
 .node-version
 .npmrc
 .gitignore
+.env.local
+.env.example

--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@ Supported variables:
 
 | Variable              | Default                         |
 | --------------------- | ------------------------------- |
-| `LIBRA2_MAINNET_URL`  | `https://mainnet.libra2.org/v1` |
+| `NODE_REST_URL`       | `https://rpc.libra2.org/v1`     |
+| `INDEXER_URL`         | `https://indexer.libra2.org`    |
 | `LIBRA2_TESTNET_URL`  | `https://testnet.libra2.org/v1` |
 | `LIBRA2_DEVNET_URL`   | `https://devnet.libra2.org/v1`  |
 | `LIBRA2_LOCAL_URL`    | `http://127.0.0.1:8080/v1`      |
 | `LIBRA2_LOCALNET_URL` | `http://127.0.0.1:8080/v1`      |
 
 Each `LIBRA2_*_URL` variable overrides the default endpoint for the matching
-network. Variables are loaded from `.env.local` and can be tailored to point to
-custom fullnodes or indexers.
+network. Use `NODE_REST_URL` to override the mainnet RPC endpoint and
+`INDEXER_URL` for rich explorer data (account resources and account history).
+Variables are loaded from `.env.local` and can be tailored to point to custom
+fullnodes or indexers.
 
 ### Running against different networks
 
@@ -55,10 +58,9 @@ If your local node runs on a non-default address, update `LIBRA2_LOCAL_URL` in
 
 ### GraphQL support
 
-Libra2's indexer does not yet provide the full GraphQL schema.
-When a GraphQL endpoint is unavailable the explorer temporarily
-falls back to REST endpoints, so some queries may be limited until
-native support is added.
+Libra2XP uses the external indexer GraphQL endpoint for rich explorer data.
+Ensure `INDEXER_URL` points at the indexer HTTP base (for example,
+`https://indexer.libra2.org`) so the app can reach `/v1/graphql`.
 
 Build dependencies:
 

--- a/src/api/hooks/useGetAccountModule.ts
+++ b/src/api/hooks/useGetAccountModule.ts
@@ -1,8 +1,28 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountModule} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountModuleResponse = {
+  move_modules: Array<{
+    bytecode: string;
+    abi?: Types.MoveModule;
+  }>;
+};
+
+const ACCOUNT_MODULE_QUERY = `
+  query AccountModule($address: String, $name: String) {
+    move_modules(
+      where: {address: {_eq: $address}, name: {_eq: $name}}
+      limit: 1
+    ) {
+      bytecode
+      abi
+    }
+  }
+`;
 
 export function useGetAccountModule(
   address: string,
@@ -12,7 +32,28 @@ export function useGetAccountModule(
 
   return useQuery<Types.MoveModuleBytecode, ResponseError>({
     queryKey: ["accountModule", {address, moduleName}, state.network_value],
-    queryFn: () => getAccountModule({address, moduleName}, state.aptos_client),
+    queryFn: async () => {
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountModuleResponse>(
+        state.network_name,
+        ACCOUNT_MODULE_QUERY,
+        {address: standardized, name: moduleName},
+      );
+      const module = data.move_modules[0];
+      if (!module) {
+        throw {type: ResponseErrorType.NOT_FOUND};
+      }
+      return {
+        bytecode: module.bytecode,
+        abi: module.abi,
+      };
+    },
     refetchOnWindowFocus: false,
   });
 }

--- a/src/api/hooks/useGetAccountModules.ts
+++ b/src/api/hooks/useGetAccountModules.ts
@@ -1,8 +1,25 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountModules} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountModulesResponse = {
+  move_modules: Array<{
+    bytecode: string;
+    abi?: Types.MoveModule;
+  }>;
+};
+
+const ACCOUNT_MODULES_QUERY = `
+  query AccountModules($address: String) {
+    move_modules(where: {address: {_eq: $address}}) {
+      bytecode
+      abi
+    }
+  }
+`;
 
 export function useGetAccountModules(
   address: string,
@@ -11,6 +28,23 @@ export function useGetAccountModules(
 
   return useQuery<Array<Types.MoveModuleBytecode>, ResponseError>({
     queryKey: ["accountModules", {address}, state.network_value],
-    queryFn: () => getAccountModules({address}, state.aptos_client),
+    queryFn: async () => {
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountModulesResponse>(
+        state.network_name,
+        ACCOUNT_MODULES_QUERY,
+        {address: standardized},
+      );
+      return data.move_modules.map((module) => ({
+        bytecode: module.bytecode,
+        abi: module.abi,
+      }));
+    },
   });
 }

--- a/src/api/hooks/useGetAccountResource.ts
+++ b/src/api/hooks/useGetAccountResource.ts
@@ -1,9 +1,29 @@
 import {Types} from "aptos";
 import {useQuery, UseQueryResult} from "@tanstack/react-query";
-import {getAccountResource} from "..";
-import {ResponseError} from "../client";
+import {ResponseError, ResponseErrorType} from "../client";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {orderBy} from "lodash";
+import {fetchIndexerGraphql} from "../indexerGraphql";
+import {tryStandardizeAddress} from "../../utils";
+
+type IndexerAccountResourceResponse = {
+  move_resources: Array<{
+    type: string;
+    data: Types.MoveResource["data"];
+  }>;
+};
+
+const ACCOUNT_RESOURCE_QUERY = `
+  query AccountResource($address: String, $type: String) {
+    move_resources(
+      where: {address: {_eq: $address}, type: {_eq: $type}}
+      limit: 1
+    ) {
+      type
+      data
+    }
+  }
+`;
 
 export type ModuleMetadata = {
   name: string;
@@ -42,10 +62,26 @@ export function useGetAccountResource(
       if (!address) {
         throw new Error("Address is undefined");
       }
-      return await getAccountResource(
-        {address, resourceType: resource},
-        state.aptos_client,
+      const standardized = tryStandardizeAddress(address);
+      if (!standardized) {
+        throw {
+          type: ResponseErrorType.INVALID_INPUT,
+          message: `Invalid address '${address}'`,
+        };
+      }
+      const data = await fetchIndexerGraphql<IndexerAccountResourceResponse>(
+        state.network_name,
+        ACCOUNT_RESOURCE_QUERY,
+        {address: standardized, type: resource},
       );
+      const resourceData = data.move_resources[0];
+      if (!resourceData) {
+        throw {type: ResponseErrorType.NOT_FOUND};
+      }
+      return {
+        type: resourceData.type,
+        data: resourceData.data,
+      };
     },
     refetchOnWindowFocus: false,
   });

--- a/src/api/hooks/useGetValidators.ts
+++ b/src/api/hooks/useGetValidators.ts
@@ -94,7 +94,11 @@ export function useGetValidators() {
   const [validators, setValidators] = useState<ValidatorData[]>([]);
 
   useEffect(() => {
-    if (activeValidators.length > 0 && validatorsRawData.length > 0) {
+    if (activeValidators.length === 0) {
+      return;
+    }
+
+    if (validatorsRawData.length > 0) {
       const validatorsCopy = JSON.parse(JSON.stringify(validatorsRawData));
 
       validatorsCopy.forEach((validator: ValidatorData) => {
@@ -105,7 +109,22 @@ export function useGetValidators() {
       });
 
       setValidators(validatorsCopy);
+      return;
     }
+
+    setValidators(
+      activeValidators.map((validator) => ({
+        owner_address: validator.addr,
+        operator_address: validator.addr,
+        voting_power: validator.voting_power,
+        governance_voting_record: "0",
+        last_epoch: 0,
+        last_epoch_performance: "0",
+        liveness: 0,
+        rewards_growth: 0,
+        apt_rewards_distributed: 0,
+      })),
+    );
   }, [activeValidators, validatorsRawData]);
 
   return {validators};

--- a/src/api/hooks/useGraphqlClient.tsx
+++ b/src/api/hooks/useGraphqlClient.tsx
@@ -17,7 +17,10 @@ function getIsGraphqlClientSupportedFor(networkName: NetworkName): boolean {
 
 function getIndexerBaseUrl(networkName: NetworkName): string | undefined {
   const defaultIndexer =
-    import.meta.env.VITE_LIBRA2_INDEXER_HTTP ?? "https://indexer.libra2.org";
+    import.meta.env.VITE_INDEXER_URL ??
+    import.meta.env.INDEXER_URL ??
+    import.meta.env.VITE_LIBRA2_INDEXER_HTTP ??
+    "https://indexer.libra2.org";
 
   if (networkName === "local" || networkName === "localnet") {
     return (
@@ -35,6 +38,13 @@ export function getGraphqlURI(networkName: NetworkName): string | undefined {
   if (!baseUrl) return undefined;
 
   const normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+
+  if (
+    normalizedBase.endsWith("/v1/graphql") ||
+    normalizedBase.endsWith("/graphql")
+  ) {
+    return normalizedBase;
+  }
 
   return `${normalizedBase}/v1/graphql`;
 }

--- a/src/api/indexerGraphql.ts
+++ b/src/api/indexerGraphql.ts
@@ -1,0 +1,71 @@
+import {getApiKey, NetworkName} from "../constants";
+import {
+  createIndexerUnavailableError,
+  isIndexerUnavailableMessage,
+  ResponseErrorType,
+} from "./client";
+import {getGraphqlURI} from "./hooks/useGraphqlClient";
+
+type GraphqlError = {
+  message?: string;
+};
+
+type GraphqlResponse<T> = {
+  data?: T;
+  errors?: GraphqlError[];
+};
+
+function buildIndexerUnavailableError(message?: string) {
+  if (isIndexerUnavailableMessage(message)) {
+    return createIndexerUnavailableError();
+  }
+  return {
+    type: ResponseErrorType.UNHANDLED,
+    message,
+  };
+}
+
+export async function fetchIndexerGraphql<T>(
+  networkName: NetworkName,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const graphqlUrl = getGraphqlURI(networkName);
+  if (!graphqlUrl) {
+    throw createIndexerUnavailableError();
+  }
+
+  const apiKey = getApiKey(networkName);
+  let response: Response;
+  try {
+    response = await fetch(graphqlUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(apiKey ? {authorization: `Bearer ${apiKey}`} : {}),
+      },
+      body: JSON.stringify({query, variables}),
+    });
+  } catch {
+    throw createIndexerUnavailableError();
+  }
+
+  const payload = (await response.json()) as GraphqlResponse<T>;
+  if (!response.ok) {
+    const message =
+      payload?.errors?.map((entry) => entry.message).join(" ") ??
+      response.statusText;
+    throw buildIndexerUnavailableError(message);
+  }
+
+  if (payload.errors?.length) {
+    const message = payload.errors.map((entry) => entry.message).join(" ");
+    throw buildIndexerUnavailableError(message);
+  }
+
+  if (!payload.data) {
+    throw buildIndexerUnavailableError("Indexer response missing data.");
+  }
+
+  return payload.data;
+}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,7 +1,7 @@
 import {CoinDescription} from "./api/hooks/useGetCoinList";
 
 const DEFAULT_NETWORK_URLS = {
-  mainnet: "https://mainnet.libra2.org/v1",
+  mainnet: "https://rpc.libra2.org/v1",
   testnet: "https://testnet.libra2.org/v1",
   devnet: "https://devnet.libra2.org/v1",
   local: "http://127.0.0.1:8080/v1",
@@ -19,6 +19,8 @@ function normalizeUrl(url?: string, fallback?: string) {
 export const networks: Record<string, string> = {
   mainnet: normalizeUrl(
     import.meta.env.LIBRA2_MAINNET_URL ??
+      import.meta.env.VITE_NODE_REST_URL ??
+      import.meta.env.NODE_REST_URL ??
       import.meta.env.VITE_LIBRA2_NODE_URL ??
       DEFAULT_NETWORK_URLS.mainnet,
     DEFAULT_NETWORK_URLS.mainnet,

--- a/src/pages/Account/Components/AccountAllTransactions.tsx
+++ b/src/pages/Account/Components/AccountAllTransactions.tsx
@@ -8,6 +8,11 @@ import {
   useGetAccountAllTransactionVersions,
 } from "../../../api/hooks/useGetAccountAllTransactions";
 import {useLogEventWithBasic} from "../hooks/useLogEventWithBasic";
+import EmptyTabContent from "../../../components/IndividualPageContent/EmptyTabContent";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../api/client";
 
 function RenderPagination({
   currentPage,
@@ -70,11 +75,22 @@ export function AccountAllTransactionsWithPagination({
     offset,
   );
 
+  if (versions.error?.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+    return (
+      <EmptyTabContent
+        message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+      />
+    );
+  }
+
   return (
     <>
       <Stack spacing={2}>
         <Box sx={{width: "auto", overflowX: "auto"}}>
-          <UserTransactionsTable versions={versions} address={address} />
+          <UserTransactionsTable
+            versions={versions.versions}
+            address={address}
+          />
         </Box>
         {numPages > 1 && (
           <Box sx={{display: "flex", justifyContent: "center"}}>
@@ -93,7 +109,16 @@ type AccountAllTransactionsProps = {
 export default function AccountAllTransactions({
   address,
 }: AccountAllTransactionsProps) {
-  let txnCount = useGetAccountAllTransactionCount(address);
+  const txnCountResponse = useGetAccountAllTransactionCount(address);
+  if (txnCountResponse.error?.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+    return (
+      <EmptyTabContent
+        message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+      />
+    );
+  }
+
+  let txnCount = txnCountResponse.count;
   let canSeeAll = true;
 
   if (txnCount === undefined) {

--- a/src/pages/Account/Error.tsx
+++ b/src/pages/Account/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -26,11 +30,9 @@ export default function Error({error, address}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -52,15 +54,6 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. This
-          can happen if the indexer reader process is not running or is still
-          catching up. Please start the indexer service for the network or try
-          again later.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/Account/Tabs/ModulesTab/Contract.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/Contract.tsx
@@ -43,6 +43,10 @@ import {encodeInputArgsForViewRequest, sortPetraFirst} from "../../../../utils";
 import {accountPagePath} from "../../Index";
 import {parseTypeTag} from "@aptos-labs/ts-sdk";
 import {WalletDeprecationBanner} from "../../../../components/WalletDeprecationBanner";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../../api/client";
 
 type ContractFormType = {
   typeArgs: string[];
@@ -82,6 +86,13 @@ function Contract({
   }
 
   if (error) {
+    if (error.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+      return (
+        <EmptyTabContent
+          message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+        />
+      );
+    }
     return <Error address={address} error={error} />;
   }
 

--- a/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
+++ b/src/pages/Account/Tabs/ModulesTab/ViewCode.tsx
@@ -25,6 +25,10 @@ import {useNavigate} from "../../../../routing";
 import SidebarItem from "../../Components/SidebarItem";
 import {Code} from "../../Components/CodeSnippet";
 import {accountPagePath} from "../../Index";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseErrorType,
+} from "../../../../api/client";
 
 interface ModuleSidebarProps {
   sortedPackages: PackageMetadata[];
@@ -242,6 +246,13 @@ function ABI({address, moduleName}: {address: string; moduleName: string}) {
   }
 
   if (error) {
+    if (error.type === ResponseErrorType.INDEXER_UNAVAILABLE) {
+      return (
+        <EmptyTabContent
+          message={`${INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL configuration.`}
+        />
+      );
+    }
     return <Error address={address} error={error} />;
   }
 

--- a/src/pages/Coin/Error.tsx
+++ b/src/pages/Coin/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -24,11 +28,9 @@ export default function Error({error, struct}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -49,13 +51,6 @@ export default function Error({error, struct}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. Please
-          ensure it is running or try again later once it has caught up.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">

--- a/src/pages/FungibleAsset/Error.tsx
+++ b/src/pages/FungibleAsset/Error.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import {ResponseError, ResponseErrorType} from "../../api/client";
+import {
+  INDEXER_UNAVAILABLE_MESSAGE,
+  ResponseError,
+  ResponseErrorType,
+} from "../../api/client";
 import {Alert} from "@mui/material";
 
 type ErrorProps = {
@@ -24,11 +28,9 @@ export default function Error({error, address}: ErrorProps) {
       );
     case ResponseErrorType.INDEXER_UNAVAILABLE:
       return (
-        <Alert severity="error" sx={{overflowWrap: "break-word"}}>
-          Indexer service unavailable. Please ensure the indexer reader for this
-          network is running and caught up, then try again.
-          <br />
-          {error.message}
+        <Alert severity="info" sx={{overflowWrap: "break-word"}}>
+          {INDEXER_UNAVAILABLE_MESSAGE} Please check your INDEXER_URL
+          configuration.
         </Alert>
       );
     case ResponseErrorType.UNHANDLED:
@@ -49,13 +51,6 @@ export default function Error({error, address}: ErrorProps) {
           </Alert>
         );
       }
-    case ResponseErrorType.INDEXER_UNAVAILABLE:
-      return (
-        <Alert severity="error">
-          The indexer service for this network is currently unavailable. Please
-          ensure it is running or try again later once it has caught up.
-        </Alert>
-      );
     case ResponseErrorType.TOO_MANY_REQUESTS:
       return (
         <Alert severity="error">


### PR DESCRIPTION
### Motivation
- The app was failing to show transactions/validators/blocks when the indexer integration or configuration produced no data or a mismatched GraphQL URL.
- Improve user-facing behavior so raw internal indexer errors are suppressed and the UI degrades gracefully.
- Provide reasonable defaults and fallbacks so the browser remains functional when external validator stats or indexer endpoints are unavailable.

### Description
- Accept full GraphQL indexer URLs by updating `getGraphqlURI` to avoid doubling `/v1/graphql` when `INDEXER_URL` already includes the path (`src/api/hooks/useGraphqlClient.tsx`).
- Add a dedicated `fetchIndexerGraphql` helper to call the indexer GraphQL endpoint and centralize error handling (`src/api/indexerGraphql.ts`).
- Centralize indexer-unavailable detection and a friendly typed error with `INDEXER_UNAVAILABLE_MESSAGE`, `isIndexerUnavailableMessage`, and `createIndexerUnavailableError` in `src/api/client.ts`.
- Switch account-related hooks to use the indexer GraphQL helper and return structured responses/errors (`useGetAccountResource`, `useGetAccountResources`, `useGetAccountModule`, `useGetAccountModules`, `useGetAccountAllTransactions`) and update UI components to show a neutral degraded state when the indexer is unavailable.
- Add a validators fallback that builds table data from on-chain active validators when external validator stats are missing (`src/api/hooks/useGetValidators.ts`).
- Update network/env defaults and docs to use `NODE_REST_URL` and `INDEXER_URL`, add `.env` files to `.prettierignore`, and refresh `README.md` (`.env.example`, `.env.local`, `.prettierignore`, `README.md`, `src/constants.tsx`).

### Testing
- Ran pre-commit hooks which executed `prettier` formatting and `eslint --fix` as part of the commit flow and they completed successfully.
- No automated unit or end-to-end tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef067bfac8332948262638e8c1683)