### PR TITLE
Replace APT labels with LBT and fix balance hook imports

### DIFF
--- a/src/api/hooks/delegations/useGetDelegationState.ts
+++ b/src/api/hooks/delegations/useGetDelegationState.ts
@@ -2,7 +2,7 @@ import {Types} from "aptos";
 import {ValidatorData} from "../useGetValidators";
 import {useWallet} from "@aptos-labs/wallet-adapter-react";
 import {getLockedUtilSecs} from "../../../pages/DelegatoryValidator/utils";
-import {useGetAccountLBTBalance} from "../useGetAccountLBTBalance";
+import {useGetAccountLBTBalance} from "../useGetAccountAPTBalance";
 import {useGetNumberOfDelegators} from "./useGetNumberOfDelegators";
 import {useGetStakingRewardsRate} from "../useGetStakingRewardsRate";
 import {addressFromWallet} from "../../../utils";

--- a/src/components/AmountTextField.tsx
+++ b/src/components/AmountTextField.tsx
@@ -30,7 +30,7 @@ export default function AmountTextField({
         notched
         value={amount}
         onChange={onAmountChange}
-        endAdornment={<InputAdornment position="end">APT</InputAdornment>}
+        endAdornment={<InputAdornment position="end">LBT</InputAdornment>}
         placeholder={
           balance
             ? `Your balance: ${getFormattedBalanceStr(balance, undefined, 1)}`

--- a/src/pages/Account/BalanceCard.tsx
+++ b/src/pages/Account/BalanceCard.tsx
@@ -5,7 +5,7 @@ import {Card} from "../../components/Card";
 import {grey} from "../../themes/colors/libra2ColorPalette";
 import StyledTooltip from "../../components/StyledTooltip";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountLBTBalance";
+import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountAPTBalance";
 import {getPrice} from "../../api/hooks/useGetPrice";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {OpenInNew} from "@mui/icons-material";
@@ -13,8 +13,8 @@ import {OpenInNew} from "@mui/icons-material";
 type BalanceCardProps = {
   address: string;
   coinType?: `0x${string}::${string}::${string}`; // 新
-  symbol?: string;                                 // 新
-  decimals?: number;                               // 新，默认 8
+  symbol?: string; // 新
+  decimals?: number; // 新，默认 8
 };
 
 export default function BalanceCard({
@@ -34,13 +34,20 @@ export default function BalanceCard({
   const [price, setPrice] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!isAPT) { setPrice(null); return; }    // 非 APT 不取价
+    if (!isAPT) {
+      setPrice(null);
+      return;
+    } // 非 APT 不取价
     (async () => {
-      try { setPrice(await getPrice()); } catch { setPrice(null); }
+      try {
+        setPrice(await getPrice());
+      } catch {
+        setPrice(null);
+      }
     })();
   }, [isAPT]);
 
-  const sym = symbol ?? (isAPT ? "APT" : "LBT");
+  const sym = symbol ?? "LBT";
   const balanceUSD =
     isAPT && balance.data && price !== null
       ? (Number(balance.data) * Number(price)) / 1e8
@@ -55,11 +62,13 @@ export default function BalanceCard({
           coinType: {theType}
         </Typography>
         {balance.isLoading && (
-          <Typography fontSize={14} color={grey[450]}>Loading balance…</Typography>
+          <Typography fontSize={14} color={grey[450]}>
+            Loading balance…
+          </Typography>
         )}
         {balance.error && (
           <Typography fontSize={12} color="error.main">
-            {String((balance.error as any)?.message ?? balance.error)}
+            {balance.error.message ?? "Failed to load balance."}
           </Typography>
         )}
 
@@ -67,23 +76,31 @@ export default function BalanceCard({
         {balance.data && (
           <>
             <Typography fontSize={17} fontWeight={700}>
-              {`${getFormattedBalanceStr(balance.data, decimals as any)} ${sym}`}
+              {`${getFormattedBalanceStr(balance.data, decimals)} ${sym}`}
             </Typography>
 
-            {isAPT && globalState.network_name === "mainnet" && balanceUSD !== null && (
-              <Typography fontSize={14} color={grey[450]}>
-                ${balanceUSD.toLocaleString(undefined, {maximumFractionDigits: 2})} USD
-              </Typography>
-            )}
+            {isAPT &&
+              globalState.network_name === "mainnet" &&
+              balanceUSD !== null && (
+                <Typography fontSize={14} color={grey[450]}>
+                  $
+                  {balanceUSD.toLocaleString(undefined, {
+                    maximumFractionDigits: 2,
+                  })}{" "}
+                  USD
+                </Typography>
+              )}
           </>
         )}
 
         <Stack direction="row" spacing={1} alignItems="center">
-          <Typography fontSize={12} color={grey[450]}>Balance</Typography>
+          <Typography fontSize={12} color={grey[450]}>
+            Balance
+          </Typography>
           <StyledTooltip
             title={`This balance reflects the amount of ${sym} tokens held in your wallet${
               isAPT && globalState.network_name === "mainnet"
-                ? ` and their live value in USD at a rate of 1 APT = $${price?.toFixed(2)}`
+                ? ` and their live value in USD at a rate of 1 LBT = $${price?.toFixed(2)}`
                 : ""
             }.`}
           >

--- a/src/pages/Analytics/Charts/DailyAvgGasUnitPriceChart.tsx
+++ b/src/pages/Analytics/Charts/DailyAvgGasUnitPriceChart.tsx
@@ -39,7 +39,7 @@ export default function DailyAvgGasUnitPriceChart({
         tooltipsLabelFunc={(context: any) => {
           const priceInteger = Math.round(context.parsed.y).toString();
           const priceInAPT = getFormattedBalanceStr(priceInteger, 8);
-          return `${priceInAPT} APT`;
+          return `${priceInAPT} LBT`;
         }}
       />
     </CardOutline>

--- a/src/pages/Analytics/Charts/DailyGasConsumptionChart.tsx
+++ b/src/pages/Analytics/Charts/DailyGasConsumptionChart.tsx
@@ -36,7 +36,7 @@ export default function DailyGasConsumptionChart({
         tooltipsLabelFunc={(context: any) => {
           const priceInteger = Math.round(context.parsed.y).toString();
           const priceInAPT = getFormattedBalanceStr(priceInteger, 0);
-          return `${priceInAPT} APT`;
+          return `${priceInAPT} LBT`;
         }}
       />
     </CardOutline>

--- a/src/pages/Analytics/NetworkInfo/TotalStake.tsx
+++ b/src/pages/Analytics/NetworkInfo/TotalStake.tsx
@@ -14,7 +14,7 @@ export default function TotalStake() {
           : "-"
       }
       label="Actively Staked"
-      tooltip="Amount of APT tokens currently held in staking pools."
+      tooltip="Amount of LBT tokens currently held in staking pools."
     />
   );
 }

--- a/src/pages/DelegatoryValidator/MyDepositsSection.tsx
+++ b/src/pages/DelegatoryValidator/MyDepositsSection.tsx
@@ -13,7 +13,7 @@ import {
 import {Types} from "aptos";
 import {useContext, useEffect, useState} from "react";
 import {getCanWithdrawPendingInactive} from "../../api";
-import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountLBTBalance";
+import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountAPTBalance";
 import {
   useGetDelegatorStakeInfo,
   StakeOperation,
@@ -201,7 +201,7 @@ function ActionsCell({
   return (
     <GeneralTableCell sx={{textAlign: "right", paddingRight: 3}}>
       <StyledTooltip
-        title={`You can't ${getButtonTextFromStatus().toLocaleLowerCase()} because minimum APT requirement is not met`}
+        title={`You can't ${getButtonTextFromStatus().toLocaleLowerCase()} because minimum LBT requirement is not met`}
         disableHoverListener={!buttonDisabled}
       >
         <span>

--- a/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
+++ b/src/pages/DelegatoryValidator/StakeOperationDialog.tsx
@@ -290,7 +290,7 @@ function StakeOperationDialogContent({
           <ContentBoxSpaceBetween>
             <ContentRowSpaceBetween
               title={"Staking Fee"}
-              value={Number(addStakeFee) / OCTA + " APT"}
+              value={Number(addStakeFee) / OCTA + " LBT"}
               tooltip={
                 <StyledLearnMoreTooltip
                   text={
@@ -341,9 +341,9 @@ function StakeOperationDialogContent({
       </DialogContent>
       <DialogActions>
         <StyledTooltip
-          title={`Minimum stake amount is ${min} APT and maximum stake amount is ${
+          title={`Minimum stake amount is ${min} LBT and maximum stake amount is ${
             Number(balance) / OCTA
-          } APT`}
+          } LBT`}
           disableHoverListener={isAmountValid}
           placement="top"
         >

--- a/src/pages/DelegatoryValidator/StakingBar.tsx
+++ b/src/pages/DelegatoryValidator/StakingBar.tsx
@@ -24,7 +24,7 @@ import {
   useGetDelegationNodeInfo,
 } from "../../api/hooks/delegations";
 import {DelegationStateContext} from "./context/DelegationContext";
-import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountLBTBalance";
+import {useGetAccountLBTBalance} from "../../api/hooks/useGetAccountAPTBalance";
 import {MINIMUM_APT_IN_POOL_FOR_EXPLORER} from "./constants";
 import {OCTA} from "../../constants";
 import {Types} from "aptos";
@@ -177,7 +177,7 @@ function StakingBarContent({
 
   const stakeButton = (
     <StyledTooltip
-      title={`You can't stake because minimum 11 APT requirement is not met`}
+      title={`You can't stake because minimum 11 LBT requirement is not met`}
       disableHoverListener={!buttonDisabled}
     >
       <span>

--- a/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
+++ b/src/pages/DelegatoryValidator/TransactionSucceededDialog.tsx
@@ -63,7 +63,7 @@ export default function TransactionSucceededDialog({
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"You've successfully unlocked "}
               <span style={{fontWeight: 600}}>{amount}</span>
-              {" APT"}
+              {" LBT"}
             </Typography>
           </Box>
         );
@@ -73,7 +73,7 @@ export default function TransactionSucceededDialog({
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"You've successfully withdrawn "}
               <span style={{fontWeight: 600}}>{amount}</span>
-              {" APT"}
+              {" LBT"}
             </Typography>
           </Box>
         );
@@ -87,7 +87,7 @@ export default function TransactionSucceededDialog({
             <Typography variant="body2" sx={{fontSize: 12}}>
               {"Soon you will see your deposit of "}
               <span style={{fontWeight: 600}}>{amount}</span>
-              {" APT in the staking pool."}
+              {" LBT in the staking pool."}
             </Typography>
           </Box>
         );

--- a/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
+++ b/src/pages/DelegatoryValidator/hooks/useAmountInput.tsx
@@ -63,16 +63,16 @@ const useAmountInput = (stakeOperation: StakeOperation) => {
             stakedAmount - Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== stakedAmount.toString()
           ) {
-            return `If you unlock ${amount} APT, your total staked amount ${stakedAmount} APT will be unlocked.`;
+            return `If you unlock ${amount} LBT, your total staked amount ${stakedAmount} LBT will be unlocked.`;
           } else if (
             amount &&
             unlockedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== stakedAmount.toString()
           ) {
             if (stakedAmount - MINIMUM_APT_IN_POOL > MINIMUM_APT_IN_POOL) {
-              return `If you unlock ${amount} APT, ${MINIMUM_APT_IN_POOL} APT will be unlocked.`;
+              return `If you unlock ${amount} LBT, ${MINIMUM_APT_IN_POOL} LBT will be unlocked.`;
             } else {
-              return `If you unlock ${amount} APT, your total staked amount ${stakedAmount} APT will be unlocked.`;
+              return `If you unlock ${amount} LBT, your total staked amount ${stakedAmount} LBT will be unlocked.`;
             }
           }
           break;
@@ -89,28 +89,28 @@ const useAmountInput = (stakeOperation: StakeOperation) => {
             stakedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== unlockedAmount.toString()
           ) {
-            return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+            return `If you restake ${amount} LBT, your total unlocked amount ${unlockedAmount} LBT will be restaked.`;
           } else if (
             amount &&
             unlockedAmount - Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== unlockedAmount.toString()
           ) {
-            return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+            return `If you restake ${amount} LBT, your total unlocked amount ${unlockedAmount} LBT will be restaked.`;
           } else if (
             amount &&
             stakedAmount + Number(amount) < MINIMUM_APT_IN_POOL &&
             amount !== unlockedAmount.toString()
           ) {
             if (unlockedAmount - MINIMUM_APT_IN_POOL > MINIMUM_APT_IN_POOL) {
-              return `If you restake ${amount} APT, ${MINIMUM_APT_IN_POOL} APT will be restaked.`;
+              return `If you restake ${amount} LBT, ${MINIMUM_APT_IN_POOL} LBT will be restaked.`;
             } else {
-              return `If you restake ${amount} APT, your total unlocked amount ${unlockedAmount} APT will be restaked.`;
+              return `If you restake ${amount} LBT, your total unlocked amount ${unlockedAmount} LBT will be restaked.`;
             }
           }
           break;
         case StakeOperation.STAKE:
           if (stakedAmount === 0) {
-            return "Minimum stake amount is 11 APT.";
+            return "Minimum stake amount is 11 LBT.";
           }
       }
     }

--- a/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
+++ b/src/pages/Transaction/Tabs/BalanceChangeTab.tsx
@@ -180,7 +180,7 @@ export default function BalanceChangeTab({transaction}: BalanceChangeTabProps) {
       known: true,
       isBanned: false,
       isInPanoraTokenList: true,
-      logoUrl: "https://assets.panora.exchange/tokens/aptos/APT.svg",
+      logoUrl: "https://assets.panora.exchange/tokens/aptos/LBT.svg",
     });
   }
 

--- a/src/pages/Validators/DelegationValidatorsTable.tsx
+++ b/src/pages/Validators/DelegationValidatorsTable.tsx
@@ -364,7 +364,7 @@ function MyDepositCell({validator}: ValidatorCellProps) {
           <CheckCircleIcon sx={{color: libra2Color}} fontSize="small" />
           <CurrencyValue
             amount={Number(totalDeposit).toString()}
-            currencyCode="APT"
+            currencyCode="LBT"
             fixedDecimalPlaces={0}
           />
         </Stack>


### PR DESCRIPTION
### Motivation
- Align UI copy and visuals to use the `LBT` token symbol everywhere `APT` was previously shown.
- Fix incorrect imports for the account-balance hook to point to the correct module to avoid TypeScript import errors.
- Improve balance rendering and error handling to remove unsafe casts and clarify formatting.

### Description
- Replaced occurrences of the `APT` label with `LBT` in multiple UI components including `AmountTextField`, `StakeOperationDialog`, `TransactionSucceededDialog`, `DailyAvgGasUnitPriceChart`, `DailyGasConsumptionChart`, `TotalStake`, `StakingBar`, `MyDepositsSection`, `DelegationValidatorsTable`, and others.
- Updated imports to use the correct balance hook module via `useGetAccountAPTBalance` where balance hooks were referenced (e.g. `useGetDelegationState.ts`, `BalanceCard.tsx`, `MyDepositsSection.tsx`, `StakingBar.tsx`).
- In `BalanceCard.tsx` set the default symbol to `LBT`, tightened error handling by replacing unsafe casts with `balance.error.message ?? "Failed to load balance."`, and removed an unnecessary cast when formatting decimals.
- Swapped the gas fee storage-refund logo URL to the `LBT` asset in `BalanceChangeTab.tsx` and adjusted stake-related messages and tooltips to reference `LBT` and updated chart tooltip labels.
- Ran formatting and lint cleanups as part of pre-commit tasks (`prettier` and `eslint --fix`).

### Testing
- Ran pre-commit tasks which executed `prettier` and `eslint --fix`, and both completed successfully.
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 4173` and confirmed the app served successfully.
- Captured a headless screenshot to validate the `LBT` logo update for the balance-change storage refund (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69705c7d81ec8332abe2dd77242e157a)