### PR TITLE
Add APT balance hook export alias

### DIFF
--- a/src/api/hooks/useGetAccountAPTBalance.ts
+++ b/src/api/hooks/useGetAccountAPTBalance.ts
@@ -3,7 +3,7 @@ import {useQuery} from "@tanstack/react-query";
 import {useGlobalState} from "../../global-config/GlobalConfig";
 import {Network, networks} from "../../constants";
 
-export function useGetAccountLBTBalance(
+export function useGetAccountAPTBalance(
   address: Types.Address,
   coinType?: `0x${string}::${string}::${string}`, // 可选：要查的币，不传=APT
 ) {
@@ -48,3 +48,5 @@ export function useGetAccountLBTBalance(
     },
   });
 }
+
+export const useGetAccountLBTBalance = useGetAccountAPTBalance;


### PR DESCRIPTION
### Motivation
- Rename the balance hook export to a clearer name and keep the old name working for backward compatibility.

### Description
- Rename the exported function to `useGetAccountAPTBalance` and add `export const useGetAccountLBTBalance = useGetAccountAPTBalance;` in `src/api/hooks/useGetAccountAPTBalance.ts` to preserve the previous import surface.

### Testing
- Ran pre-commit tasks (`prettier --config .prettierrc.json -w` and `eslint --fix`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712ab683a88332ab7dcd6e4f381b8a)