### PR TITLE
Fix LBT balance hook export

### DIFF
--- a/src/api/hooks/useGetAccountAPTBalance.ts
+++ b/src/api/hooks/useGetAccountAPTBalance.ts
@@ -49,4 +49,9 @@ export function useGetAccountAPTBalance(
   });
 }
 
-export const useGetAccountLBTBalance = useGetAccountAPTBalance;
+export function useGetAccountLBTBalance(
+  address: Types.Address,
+  coinType?: `0x${string}::${string}::${string}`,
+) {
+  return useGetAccountAPTBalance(address, coinType);
+}


### PR DESCRIPTION
### Motivation
- Provide an explicit `useGetAccountLBTBalance` export so TypeScript imports of the LBT balance hook resolve without errors.

### Description
- Replace the previous alias with a named wrapper `useGetAccountLBTBalance(address, coinType)` that delegates to `useGetAccountAPTBalance` in `src/api/hooks/useGetAccountAPTBalance.ts`.

### Testing
- Ran `prettier --config .prettierrc.json -w` and `eslint --fix` via commit hooks and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712dfea7488332b896010930e15eea)